### PR TITLE
[Docs] [Qt] RPC-Console documentation

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -392,6 +392,28 @@ void RPCExecutor::request(const QString &command)
     {
         std::string result;
         std::string executableCommand = command.toStdString() + "\n";
+
+        // Catch the console-only-help command before RPC call is executed and reply with help text as-if a RPC reply.
+        if(executableCommand == "help-console\n")
+        {
+            Q_EMIT reply(RPCConsole::CMD_REPLY, QString(("\n"
+                "This console accepts RPC commands using the standard syntax.\n"
+                "   example:    getblockhash 8\n\n"
+
+                "This console can also accept RPC commands using bracketed syntax.\n"
+                "   example:    getblockhash(8)\n\n"
+
+                "A space or a comma can be used to separate arguments for either syntax.\n"
+                "   example:    sendtoaddress <address> <amount>\n"
+                "               sendtoaddress,<address>,<amount>\n\n"
+
+                "Commands may be nested when specified with the bracketed syntax.\n"
+                "   example:    getblockinfo(getblockhash(0),true).\n\n"
+
+                "Result values can be queried with a non-quoted string in brackets.\n"
+                "   example:    getblock(getblockhash(0) true)[height]\n\n" )));
+            return;
+        }
         if(!RPCConsole::RPCExecuteCommandLine(result, executableCommand))
         {
             Q_EMIT reply(RPCConsole::CMD_ERROR, QString("Parse error: unbalanced ' or \""));
@@ -747,10 +769,12 @@ void RPCConsole::clear(bool clearHistory)
 #else
     QString clsKey = "Ctrl-L";
 #endif
-	 
+
     message(CMD_REPLY, (tr("Welcome to the %1 RPC console.").arg(tr(PACKAGE_NAME)) + "<br>" +
                         tr("Use up and down arrows to navigate history, and %1 to clear screen.").arg("<b>"+clsKey+"</b>") + "<br>" +
-                        tr("Type <b>help</b> for an overview of available commands.")) +
+                        tr("Type <b>help</b> for an overview of available commands.<br>") +
+                        tr("For more information on using this console type <b>help-console</b>.<br>")) +
+
                         "<br><span class=\"secwarning\">" +
                         tr("WARNING: Scammers have been active, telling users to type commands here, stealing their wallet contents. Do not use this console without fully understanding the ramifications of a command.") +
                         "</span>",


### PR DESCRIPTION
This PR would close -- by adding documentation for the debug console features (mainly nested commands) which were added in --.

The following changes were made to QT debug console code:
- Added a line to the initial message text at the top of the debug console:  

> For more information on using this console type **help-console**.

- Added a pseudo-command `help-console` which is hooked after parsing the request, but before actually executing the RPC thread. It prints the following text to the console as if it were a valid RPC response.

> This console accepts RPC commands using the standard syntax.
>    example:    getblockhash 8
> 
> This console can also accept RPC commands using bracketed syntax.
>    example:    getblockhash(8)
> 
> A space or a comma can be used to separate arguments for either syntax.
>    example:    sendtoaddress <address> <amount>
>                    sendtoaddress,<address>,<amount>
> Commands may be nested when specified with the bracketed syntax.
>    example:    getblockinfo(getblockhash(0),true).
> Result values can be queried with a non-quoted string in brackets.
>    example:    getblock(getblockhash(0) true)[height]

This seemed like a reasonably sane way to introduce a fake RPC help command, and among the least disruptive options.